### PR TITLE
Fix: Remove hhvm-nightly from build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,9 @@ php:
   - 5.6
   - 7.0
   - hhvm
-  - hhvm-nightly
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - php: hhvm-nightly
 
 before_script:
   - rm -f ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini


### PR DESCRIPTION
This PR

* [x] removes `hhvm-nightly` from the build matrix 

> HHVM nightly is no longer supported on Ubuntu Precise. See https://github.com/travis-ci/travis-ci/issues/3788 and https://github.com/facebook/hhvm/issues/5220