### PR TITLE
Enhancement: Run php-cs-fixer on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,15 @@ matrix:
   allow_failures:
     - php: hhvm-nightly
 
+before_install:
+  - if [[ "$TRAVIS_PHP_VERSION" == "5.6" ]]; then composer require --dev fabpot/php-cs-fixer:^1.9; fi
+
+install:
+  - composer install --no-interaction --no-progress --prefer-dist
+
 before_script:
   - rm -f ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini
-  - composer install --no-interaction --no-progress --prefer-dist
 
 script:
   - vendor/bin/phpunit
+  - if [[ "$TRAVIS_PHP_VERSION" == "5.6" ]]; then vendor/bin/php-cs-fixer fix --config-file=.php_cs --diff --verbose --dry-run; fi


### PR DESCRIPTION
This PR

* [x] requires `fabpot/php-cs-fixer` in the `before_install` section running against PHP 5.6
* [x] installs dependencies in the the `install` section
* [x] runs `php-cs-fixer` when building against PHP 5.6 configuration

:information_desk_person: The idea here is to make actual use of the checked in configuration, see https://github.com/composer/semver/blob/master/.php_cs.