### PR TITLE
Remove useless platform override

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,11 +36,6 @@
         "phpunit/phpunit": "~4.5",
         "phpunit/phpunit-mock-objects": "~2.3"
     },
-    "config": {
-        "platform": {
-            "php": "5.3.3"
-        }
-    },
     "autoload": {
         "psr-4": {
             "Composer\\Semver\\": "src"


### PR DESCRIPTION
We don't commit a lock file in the repo, so there is no need to force the PHP 5.3.3 compatibility when resolving deps