### PR TITLE
Collapse contiguous constraints when possible

### DIFF
--- a/tests/VersionParserTest.php
+++ b/tests/VersionParserTest.php
@@ -390,6 +390,15 @@ class VersionParserTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testParseConstraintsMultiCollapsesContiguous()
+    {
+        $parser = new VersionParser();
+        $first = new Constraint('>=', '2.5.0.0-dev');
+        $second = new Constraint('<', '4.0.0.0-dev');
+        $multi = new MultiConstraint(array($first, $second));
+        $this->assertSame((string) $multi, (string) $parser->parseConstraints('^2.5 || ^3.0'));
+    }
+
     /**
      * @dataProvider multiConstraintProvider
      */


### PR DESCRIPTION
This only handles simple `X.Y || X+1.0` cases right now, but I think it's the most common and helpful. `X.Y || X+1.0 || X+2.0` might be relevant but not sure it's worth the extra parsing time, especially considering building something compatible with 3 different major versions is kinda unlikely, most people would drop X.Y eventually along the way.