### PR TITLE
Update `.php_cs` to work with fresh php-cs-fixer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -9,6 +9,8 @@ For the full copyright and license information, please view
 the LICENSE file that was distributed with this source code.
 EOF;
 
+Symfony\CS\Fixer\Contrib\HeaderCommentFixer::setHeader($header);
+
 $finder = Symfony\CS\Finder\DefaultFinder::create()
     ->files()
     ->name('*.php')
@@ -18,38 +20,39 @@ $finder = Symfony\CS\Finder\DefaultFinder::create()
 
 /* fabpot/php-cs-fixer:^2.0-dev */
 return Symfony\CS\Config\Config::create()
-    ->setRules(array(
-        '@PSR2' => true,
-        'duplicate_semicolon' => true,
-        'extra_empty_lines' => true,
-        'header_comment' => array('header' => $header),
-        'include' => true,
-        'long_array_syntax' => true,
-        'method_separation' => true,
-        'multiline_array_trailing_comma' => true,
-        'namespace_no_leading_whitespace' => true,
-        'no_blank_lines_after_class_opening' => true,
-        'no_empty_lines_after_phpdocs' => true,
-        'object_operator' => true,
-        'operators_spaces' => true,
-        'phpdoc_indent' => true,
-        'phpdoc_no_access' => true,
-        'phpdoc_no_package' => true,
-        'phpdoc_order' => true,
-        'phpdoc_scalar' => true,
-        'phpdoc_separation' => true,
-        'phpdoc_trim' => true,
-        'phpdoc_type_to_var' => true,
-        'return' => true,
-        'remove_leading_slash_use' => true,
-        'remove_lines_between_uses' => true,
-        'single_array_no_trailing_comma' => true,
-        'single_blank_line_before_namespace' => true,
-        'spaces_cast' => true,
-        'standardize_not_equal' => true,
-        'ternary_spaces' => true,
-        'unused_use' => true,
-        'whitespacy_lines' => true,
+    ->level(Symfony\CS\FixerInterface::PSR2_LEVEL)
+    ->fixers(array(
+        '@PSR2',
+        'duplicate_semicolon',
+        'extra_empty_lines',
+        'header_comment',
+        'include',
+        'long_array_syntax',
+        'method_separation',
+        'multiline_array_trailing_comma',
+        'namespace_no_leading_whitespace',
+        'no_blank_lines_after_class_opening',
+        'no_empty_lines_after_phpdocs',
+        'object_operator',
+        'operators_spaces',
+        'phpdoc_indent',
+        'phpdoc_no_access',
+        'phpdoc_no_package',
+        'phpdoc_order',
+        'phpdoc_scalar',
+        'phpdoc_separation',
+        'phpdoc_trim',
+        'phpdoc_type_to_var',
+        'return',
+        'remove_leading_slash_use',
+        'remove_lines_between_uses',
+        'single_array_no_trailing_comma',
+        'single_blank_line_before_namespace',
+        'spaces_cast',
+        'standardize_not_equal',
+        'ternary_spaces',
+        'unused_use',
+        'whitespacy_lines',
     ))
     ->finder($finder)
 ;


### PR DESCRIPTION
When running fresh php-cs-fixer (1.11.2) it fails because of your `.php_cs` config file:

```
PHP Fatal error:  Call to undefined method Symfony\CS\Config\Config::setRules() in /home/sol/prj/composer/semver/.php_cs on line 21
```

I think it's because this config is for older php-cs-fixer.

So I changed it in a style the php-cs-fixer has: https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/1.12/.php_cs

If you prefer to stick with your older php-cs-fixer version may be you could require-dev needed version in your composer.json.