### PR TITLE
Parsing "7.0.8-1~dotdeb" version pattern for PHP

### DIFF
--- a/src/VersionParser.php
+++ b/src/VersionParser.php
@@ -125,6 +125,11 @@ class VersionParser
             $version = $match[1];
         }
 
+        // parse PHP versions in format of "7.0.8-1~dotdeb"
+        if(preg_match('{([^,\\s+]+[0-9])-[0-9]~}', $version, $match)){
+            $version = $match[1];
+        }
+
         // match classical versioning
         if (preg_match('{^v?(\d{1,5})(\.\d++)?(\.\d++)?(\.\d++)?' . self::$modifierRegex . '$}i', $version, $matches)) {
             $version = $matches[1]

--- a/tests/VersionParserTest.php
+++ b/tests/VersionParserTest.php
@@ -94,6 +94,7 @@ class VersionParserTest extends \PHPUnit_Framework_TestCase
             // not supported for BC 'semver metadata/7' => array('1.0.0-0.3.7', '1.0.0.0-0.3.7'),
             // not supported for BC 'semver metadata/8' => array('1.0.0-x.7.z.92', '1.0.0.0-x.7.z.92'),
             'metadata w/ alias' => array('1.0.0+foo as 2.0', '1.0.0.0'),
+            'parses PHP version' => array('7.0.8-1~dotdeb', '7.0.8')
         );
     }
 

--- a/tests/VersionParserTest.php
+++ b/tests/VersionParserTest.php
@@ -94,7 +94,7 @@ class VersionParserTest extends \PHPUnit_Framework_TestCase
             // not supported for BC 'semver metadata/7' => array('1.0.0-0.3.7', '1.0.0.0-0.3.7'),
             // not supported for BC 'semver metadata/8' => array('1.0.0-x.7.z.92', '1.0.0.0-x.7.z.92'),
             'metadata w/ alias' => array('1.0.0+foo as 2.0', '1.0.0.0'),
-            'parses PHP version' => array('7.0.8-1~dotdeb', '7.0.8')
+            'parses PHP version' => array('7.0.8-1~dotdeb', '7.0.8.0')
         );
     }
 


### PR DESCRIPTION
At least the Dotdeb (https://www.dotdeb.org) packaging uses the format 7.0.8-1~dotdeb for version numbers. This causes PHP version checks to fail:

```
[UnexpectedValueException]
Invalid version string "7.0.8-1~dotdeb"
```

This PR adds parsing that will match this pattern to semver.