### PR TITLE
Added support for dates with format `Ymd.minor.patch`

### DIFF
--- a/src/VersionParser.php
+++ b/src/VersionParser.php
@@ -133,7 +133,7 @@ class VersionParser
                 . (!empty($matches[4]) ? $matches[4] : '.0');
             $index = 5;
         // match date(time) based versioning
-        } elseif (preg_match('{^v?(\d{4}(?:[.:-]?\d{2}){1,6}(?:[.:-]?\d{1,3})?)' . self::$modifierRegex . '$}i', $version, $matches)) {
+        } elseif (preg_match('{^v?(\d{4}(?:[.:-]?\d{1,2}){1,6}(?:[.:-]?\d{1,3})?)' . self::$modifierRegex . '$}i', $version, $matches)) {
             $version = preg_replace('{\D}', '.', $matches[1]);
             $index = 2;
         }

--- a/tests/VersionParserTest.php
+++ b/tests/VersionParserTest.php
@@ -76,6 +76,7 @@ class VersionParserTest extends \PHPUnit_Framework_TestCase
             'parses numbers' => array('2010-01-02.5', '2010.01.02.5'),
             'parses dates y.m.Y' => array('2010.1.555', '2010.1.555.0'),
             'parses datetime' => array('20100102-203040', '20100102.203040'),
+            'parses dates Ymd.minor.patch' => array('20150920.0.0', '20150920.0.0'),
             'parses dt+number' => array('20100102203040-10', '20100102203040.10'),
             'parses dt+patch' => array('20100102-203040-p1', '20100102.203040-patch1'),
             'parses master' => array('dev-master', '9999999-dev'),


### PR DESCRIPTION
Works identical to `major.minor.patch`.
Fixes #32, https://github.com/fxpio/composer-asset-plugin/issues/185
