### PR TITLE
Add test for maven style version (SNAPSHOT)

### DIFF
--- a/tests/VersionParserTest.php
+++ b/tests/VersionParserTest.php
@@ -94,7 +94,6 @@ class VersionParserTest extends \PHPUnit_Framework_TestCase
             // not supported for BC 'semver metadata/7' => array('1.0.0-0.3.7', '1.0.0.0-0.3.7'),
             // not supported for BC 'semver metadata/8' => array('1.0.0-x.7.z.92', '1.0.0.0-x.7.z.92'),
             'metadata w/ alias' => array('1.0.0+foo as 2.0', '1.0.0.0'),
-            'maven style release' => array('1.0.1-SNAPSHOT', '1.0.1-SNAPSHOT'),
         );
     }
 
@@ -117,6 +116,7 @@ class VersionParserTest extends \PHPUnit_Framework_TestCase
             'too many bits' => array('1.0.0.0.0'),
             'non-dev arbitrary' => array('feature-foo'),
             'metadata w/ space' => array('1.0.0+foo bar'),
+            'maven style release' => array('1.0.1-SNAPSHOT'),
         );
     }
 

--- a/tests/VersionParserTest.php
+++ b/tests/VersionParserTest.php
@@ -94,6 +94,7 @@ class VersionParserTest extends \PHPUnit_Framework_TestCase
             // not supported for BC 'semver metadata/7' => array('1.0.0-0.3.7', '1.0.0.0-0.3.7'),
             // not supported for BC 'semver metadata/8' => array('1.0.0-x.7.z.92', '1.0.0.0-x.7.z.92'),
             'metadata w/ alias' => array('1.0.0+foo as 2.0', '1.0.0.0'),
+            'maven style release' => array('1.0.1-SNAPSHOT', '1.0.1-SNAPSHOT'),
         );
     }
 


### PR DESCRIPTION
This PR is made to start a discussion about how to handle the "-SNAPSHOT" versions.
I've added a test that fails with

```UnexpectedValueException: Invalid version string "1.0.1-SNAPSHOT"```
Instead, I'm expecting that this value is correct as the "10.4.13-b" is.


If you are not interested in this discussion, sorry and please close it.