### PR TITLE
Use PSR-1 for PHPUnit TestCase

### DIFF
--- a/tests/ComparatorTest.php
+++ b/tests/ComparatorTest.php
@@ -11,10 +11,12 @@
 
 namespace Composer\Semver;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @coversDefaultClass \Composer\Semver\Comparator
  */
-class ComparatorTest extends \PHPUnit_Framework_TestCase
+class ComparatorTest extends TestCase
 {
     /**
      * @covers ::greaterThan

--- a/tests/Constraint/ConstraintTest.php
+++ b/tests/Constraint/ConstraintTest.php
@@ -11,7 +11,9 @@
 
 namespace Composer\Semver\Constraint;
 
-class ConstraintTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ConstraintTest extends TestCase
 {
     public static function successfulVersionMatches()
     {

--- a/tests/Constraint/MultiConstraintTest.php
+++ b/tests/Constraint/MultiConstraintTest.php
@@ -11,7 +11,9 @@
 
 namespace Composer\Semver\Constraint;
 
-class MultiConstraintTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class MultiConstraintTest extends TestCase
 {
     public function testMultiVersionMatchSucceeds()
     {

--- a/tests/SemverTest.php
+++ b/tests/SemverTest.php
@@ -11,10 +11,12 @@
 
 namespace Composer\Semver;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @coversDefaultClass \Composer\Semver\Semver
  */
-class SemverTest extends \PHPUnit_Framework_TestCase
+class SemverTest extends TestCase
 {
     /**
      * @covers ::satisfies

--- a/tests/VersionParserTest.php
+++ b/tests/VersionParserTest.php
@@ -14,8 +14,9 @@ namespace Composer\Semver;
 use Composer\Semver\Constraint\EmptyConstraint;
 use Composer\Semver\Constraint\MultiConstraint;
 use Composer\Semver\Constraint\Constraint;
+use PHPUnit\Framework\TestCase;
 
-class VersionParserTest extends \PHPUnit_Framework_TestCase
+class VersionParserTest extends TestCase
 {
     /**
      * @dataProvider numericAliasVersions


### PR DESCRIPTION
Simple version of [composer/semver#56](https://github.com/composer/semver/pull/56).

Use [PSR-1](http://www.php-fig.org/psr/psr-1/#namespace-and-class-names) while extending PHPUnit TestCase class. This will help us when to migrate to PHPUnit 6, that [no longer support snake case namespaces](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).