### PR TITLE
nit on missing class name in deprecation notice

### DIFF
--- a/src/Constraint/AbstractConstraint.php
+++ b/src/Constraint/AbstractConstraint.php
@@ -11,7 +11,7 @@
 
 namespace Composer\Semver\Constraint;
 
-trigger_error('The ' . __CLASS__ . ' abstract class is deprecated, there is no replacement for it, it will be removed in the next major version.', E_USER_DEPRECATED);
+trigger_error('The ' . AbstractConstraint::class . ' abstract class is deprecated, there is no replacement for it, it will be removed in the next major version.', E_USER_DEPRECATED);
 
 /**
  * Base constraint class.


### PR DESCRIPTION
`__CLASS__` is only defined inside of a class. The error message was previously `The  abstract class...`,
this changes it to `The Composer\Semver\Constraint\AbstractConstraint abstract class...`

Detected via static analysis.