### PR TITLE
Use __NAMESPACE__ because ::class won't work in php 5.3

### DIFF
--- a/src/Constraint/AbstractConstraint.php
+++ b/src/Constraint/AbstractConstraint.php
@@ -11,7 +11,7 @@
 
 namespace Composer\Semver\Constraint;
 
-trigger_error('The ' . __CLASS__ . ' abstract class is deprecated, there is no replacement for it, it will be removed in the next major version.', E_USER_DEPRECATED);
+trigger_error('The ' . __NAMESPACE__ . '\AbstractConstraint abstract class is deprecated, there is no replacement for it, it will be removed in the next major version.', E_USER_DEPRECATED);
 
 /**
  * Base constraint class.


### PR DESCRIPTION
Patched version of #64 - tested with 5.3 in 3v4l.org