### PR TITLE
Adapt to recent PHPUnit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,8 +34,7 @@
         "php": "^5.3.2 || ^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.5 || ^5.0.5",
-        "phpunit/phpunit-mock-objects": "2.3.0 || ^3.0"
+        "phpunit/phpunit": "^5.2"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Constraint/ConstraintTest.php
+++ b/tests/Constraint/ConstraintTest.php
@@ -142,7 +142,7 @@ class ConstraintTest extends TestCase
      */
     public function testInvalidOperators($version, $operator, $expected)
     {
-        $this->setExpectedException($expected);
+        $this->expectException($expected);
 
         new Constraint($operator, $version);
     }


### PR DESCRIPTION
This allows the tests to pass on recent versions of PHPUnit (tested with versions 7.5.6 and 8.0.5).