### PR TITLE
Don't try to parse aliases versions which doesn't contain exact version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor/
 .php_cs.cache
 composer.lock
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 vendor/
 .php_cs.cache
 composer.lock
-.idea

--- a/src/VersionParser.php
+++ b/src/VersionParser.php
@@ -108,7 +108,8 @@ class VersionParser
 
         // strip off aliasing
         if (preg_match('{^([^,\s]++) ++as ++([^,\s]++)$}', $version, $match)) {
-	        $this->normalize( $match[2] );
+            // verify that the alias is a version without constraint
+            $this->normalize($match[2]);
 
             $version = $match[1];
         }

--- a/src/VersionParser.php
+++ b/src/VersionParser.php
@@ -106,6 +106,13 @@ class VersionParser
             $fullVersion = $version;
         }
 
+	    if (preg_match('{^(\^[^,\s]++) ++as ++([^,\s\^]++)$}', $version, $match) ||
+	        preg_match('{^([^,\s]++) ++as ++(\^[^,\s\^]++)$}', $version, $match) ||
+	        preg_match('{^([^,\s]++) ++as ++(\~[^,\s\^]++)$}', $version, $match) ||
+	        preg_match('{^(\~[^,\s]++) ++as ++([^,\s\^]++)$}', $version, $match)) {
+		    throw new \UnexpectedValueException('the alias must be an exact version');
+	    }
+
         // strip off aliasing
         if (preg_match('{^([^,\s]++) ++as ++([^,\s]++)$}', $version, $match)) {
             $version = $match[1];

--- a/src/VersionParser.php
+++ b/src/VersionParser.php
@@ -106,15 +106,10 @@ class VersionParser
             $fullVersion = $version;
         }
 
-	    if (preg_match('{^(\^[^,\s]++) ++as ++([^,\s\^]++)$}', $version, $match) ||
-	        preg_match('{^([^,\s]++) ++as ++(\^[^,\s\^]++)$}', $version, $match) ||
-	        preg_match('{^([^,\s]++) ++as ++(\~[^,\s\^]++)$}', $version, $match) ||
-	        preg_match('{^(\~[^,\s]++) ++as ++([^,\s\^]++)$}', $version, $match)) {
-		    throw new \UnexpectedValueException('the alias must be an exact version');
-	    }
-
         // strip off aliasing
         if (preg_match('{^([^,\s]++) ++as ++([^,\s]++)$}', $version, $match)) {
+	        $this->normalize( $match[2] );
+
             $version = $match[1];
         }
 

--- a/tests/VersionParserTest.php
+++ b/tests/VersionParserTest.php
@@ -123,6 +123,10 @@ class VersionParserTest extends TestCase
             'non-dev arbitrary' => array('feature-foo'),
             'metadata w/ space' => array('1.0.0+foo bar'),
             'maven style release' => array('1.0.1-SNAPSHOT'),
+            'Alias and caret on left side' => array('^1.0.0+foo as 2.0'),
+            'Alias and caret on right side' => array('1.0.0+foo as ^2.0'),
+            'Alias and tilde on left side' => array('~1.0.0+foo as 2.0'),
+            'Alias and tilde on right side' => array('1.0.0+foo as ~2.0'),
         );
     }
 

--- a/tests/VersionParserTest.php
+++ b/tests/VersionParserTest.php
@@ -123,10 +123,10 @@ class VersionParserTest extends TestCase
             'non-dev arbitrary' => array('feature-foo'),
             'metadata w/ space' => array('1.0.0+foo bar'),
             'maven style release' => array('1.0.1-SNAPSHOT'),
-            'Alias and caret on left side' => array('^1.0.0+foo as 2.0'),
-            'Alias and caret on right side' => array('1.0.0+foo as ^2.0'),
-            'Alias and tilde on left side' => array('~1.0.0+foo as 2.0'),
-            'Alias and tilde on right side' => array('1.0.0+foo as ~2.0'),
+            'Alias and caret' => array('1.0.0+foo as ^2.0'),
+            'Alias and tilde' => array('1.0.0+foo as ~2.0'),
+            'Alias and greater than' => array('1.0.0+foo as >2.0'),
+            'Alias and less than' => array('1.0.0+foo as <2.0'),
         );
     }
 


### PR DESCRIPTION
This has been reported in: https://github.com/composer/composer/issues/8338

Originally it was accepting such format "8.3.3 as ^8.3" when using `composer require` (it was taking the `8.3.3` version) and then saving it on `composer.json`. However, when you run any other command after, you were getting the message "the alias must be an exact version".

So, I choose to throw an exception whenever an alias is used in the version without passing exact versions in order to comply with the message that we get.