### PR TITLE
Mention return type in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The `Composer\Semver\Comparator` class provides the following methods for compar
 * equalTo($v1, $v2)
 * notEqualTo($v1, $v2)
 
-Each function takes two version strings as arguments. For example:
+Each function takes two version strings as arguments and returns a boolean. For example:
 
 ```php
 use Composer\Semver\Comparator;


### PR DESCRIPTION
Mention that all the methods return a boolean, this is semi-obvious but I wasn't certain as the example doesn't use the return value and the comment in the example gave me doubts (perhaps it returns a string or special type for use within Composer?)

It took all of 10 seconds to look at the source and confirm but thought it might be worthwhile to mention it in the README.