### PR TITLE
Optimize MultiConstraint

### DIFF
--- a/src/Constraint/MultiConstraint.php
+++ b/src/Constraint/MultiConstraint.php
@@ -198,7 +198,7 @@ class MultiConstraint implements ConstraintInterface
             $lc = $constraints[0];
             $mergedConstraints = array();
             $optimized = false;
-            for ($i = 1, $l = count($constraints); $i <$l; $i++) {
+            for ($i = 1, $l = \count($constraints); $i <$l; $i++) {
                 $rc = $constraints[$i];
                 if (
                     $lc instanceof MultiConstraint
@@ -206,11 +206,11 @@ class MultiConstraint implements ConstraintInterface
                     && $rc instanceof MultiConstraint
                     && $rc->conjunctive
                     && ($lc0 = (string) $lc->constraints[0])
-                    && substr($lc0, 0, 2) === '>='
+                    && $lc0[0] === '>' && $lc0[1] === '='
                     && ($lc1 = (string) $lc->constraints[1])
                     && $lc1[0] === '<'
                     && ($rc0 = (string) $rc->constraints[0])
-                    && substr($rc0, 0, 2) === '>='
+                    && $rc0[0] === '>' && $rc0[1] === '='
                     && ($rc1 = (string) $rc->constraints[1])
                     && $rc1[0] === '<'
                     && substr($lc1, 2) === substr($rc0, 3)

--- a/src/Constraint/MultiConstraint.php
+++ b/src/Constraint/MultiConstraint.php
@@ -216,10 +216,10 @@ class MultiConstraint implements ConstraintInterface
                     && substr($c01, 2) === substr($c10, 3)
                 ) {
                     $optimized = true;
-                    $lc = new MultiConstraint([
+                    $lc = new MultiConstraint(array(
                         $lc->constraints[0],
                         $rc->constraints[1],
-                    ], true);
+                    ), true);
                 } else {
                     $mergedConstraints[] = $lc;
                     $lc = $rc;
@@ -227,7 +227,7 @@ class MultiConstraint implements ConstraintInterface
             }
             if ($optimized) {
                 $mergedConstraints[] = $lc;
-                return [$mergedConstraints, false];
+                return array($mergedConstraints, false);
             }
         }
 

--- a/src/Constraint/MultiConstraint.php
+++ b/src/Constraint/MultiConstraint.php
@@ -195,44 +195,44 @@ class MultiConstraint implements ConstraintInterface
         // them into one constraint
         // [>= 1 < 2] || [>= 2 < 3] || [>= 3 < 4] => [>= 1 < 4]
         if (!$conjunctive) {
-            $lc = $constraints[0];
+            $left = $constraints[0];
             $mergedConstraints = array();
             $optimized = false;
             for ($i = 1, $l = \count($constraints); $i <$l; $i++) {
-                $rc = $constraints[$i];
+                $right = $constraints[$i];
                 if (
-                    $lc instanceof MultiConstraint
-                    && $lc->conjunctive
-                    && $rc instanceof MultiConstraint
-                    && $rc->conjunctive
-                    && ($lc0 = (string) $lc->constraints[0])
-                    && $lc0[0] === '>' && $lc0[1] === '='
-                    && ($lc1 = (string) $lc->constraints[1])
-                    && $lc1[0] === '<'
-                    && ($rc0 = (string) $rc->constraints[0])
-                    && $rc0[0] === '>' && $rc0[1] === '='
-                    && ($rc1 = (string) $rc->constraints[1])
-                    && $rc1[0] === '<'
-                    && substr($lc1, 2) === substr($rc0, 3)
+                    $left instanceof MultiConstraint
+                    && $left->conjunctive
+                    && $right instanceof MultiConstraint
+                    && $right->conjunctive
+                    && ($left0 = (string) $left->constraints[0])
+                    && $left0[0] === '>' && $left0[1] === '='
+                    && ($left1 = (string) $left->constraints[1])
+                    && $left1[0] === '<'
+                    && ($right0 = (string) $right->constraints[0])
+                    && $right0[0] === '>' && $right0[1] === '='
+                    && ($right1 = (string) $right->constraints[1])
+                    && $right1[0] === '<'
+                    && substr($left1, 2) === substr($right0, 3)
                 ) {
                     $optimized = true;
-                    $lc = new MultiConstraint(
+                    $left = new MultiConstraint(
                         array_merge(
                             array(
-                                $lc->constraints[0],
-                                $rc->constraints[1],
+                                $left->constraints[0],
+                                $right->constraints[1],
                             ),
-                            \array_slice($lc->constraints, 2),
-                            \array_slice($rc->constraints, 2)
+                            \array_slice($left->constraints, 2),
+                            \array_slice($right->constraints, 2)
                         ),
                         true);
                 } else {
-                    $mergedConstraints[] = $lc;
-                    $lc = $rc;
+                    $mergedConstraints[] = $left;
+                    $left = $right;
                 }
             }
             if ($optimized) {
-                $mergedConstraints[] = $lc;
+                $mergedConstraints[] = $left;
                 return array($mergedConstraints, false);
             }
         }

--- a/src/Constraint/MultiConstraint.php
+++ b/src/Constraint/MultiConstraint.php
@@ -196,7 +196,7 @@ class MultiConstraint implements ConstraintInterface
         // [>= 1 < 2] || [>= 2 < 3] || [>= 3 < 4] => [>= 1 < 4]
         if (!$conjunctive) {
             $lc = $constraints[0];
-            $mergedConstraints = [];
+            $mergedConstraints = array();
             $optimized = false;
             for ($i = 1, $l = count($constraints); $i <$l; $i++) {
                 $rc = $constraints[$i];

--- a/src/Constraint/MultiConstraint.php
+++ b/src/Constraint/MultiConstraint.php
@@ -202,24 +202,30 @@ class MultiConstraint implements ConstraintInterface
                 $rc = $constraints[$i];
                 if (
                     $lc instanceof MultiConstraint
+                    && $lc->conjunctive
                     && $rc instanceof MultiConstraint
-                    && 2 === count($lc->constraints)
-                    && 2 === count($rc->constraints)
-                    && ($c01 = (string) $lc->constraints[1])
-                    && $c01[0] === '<'
-                    && ($c00 = (string) $lc->constraints[0])
-                    && substr($c00, 0, 2) === '>='
-                    && ($c11 = (string) $rc->constraints[1])
-                    && $c11[0] === '<'
-                    && ($c10 = (string) $rc->constraints[0])
-                    && substr($c10, 0, 2) === '>='
-                    && substr($c01, 2) === substr($c10, 3)
+                    && $rc->conjunctive
+                    && ($lc0 = (string) $lc->constraints[0])
+                    && substr($lc0, 0, 2) === '>='
+                    && ($lc1 = (string) $lc->constraints[1])
+                    && $lc1[0] === '<'
+                    && ($rc0 = (string) $rc->constraints[0])
+                    && substr($rc0, 0, 2) === '>='
+                    && ($rc1 = (string) $rc->constraints[1])
+                    && $rc1[0] === '<'
+                    && substr($lc1, 2) === substr($rc0, 3)
                 ) {
                     $optimized = true;
-                    $lc = new MultiConstraint(array(
-                        $lc->constraints[0],
-                        $rc->constraints[1],
-                    ), true);
+                    $lc = new MultiConstraint(
+                        array_merge(
+                            array(
+                                $lc->constraints[0],
+                                $rc->constraints[1],
+                            ),
+                            \array_slice($lc->constraints, 2),
+                            \array_slice($rc->constraints, 2)
+                        ),
+                        true);
                 } else {
                     $mergedConstraints[] = $lc;
                     $lc = $rc;

--- a/tests/Constraint/MultiConstraintTest.php
+++ b/tests/Constraint/MultiConstraintTest.php
@@ -293,31 +293,36 @@ class MultiConstraintTest extends TestCase
                     true // conjunctive
                 ),
             ),
-            'Test collapses multiple contiguous with intermediate range' => array(
+            'Test collapses multiple contiguous with other constraint' => array(
                 '^1.0 || ^2.0 !=2.0.1 || ^3.0 || ^4.0',
                 new MultiConstraint(
                     array(
-                        new MultiConstraint(
-                            array(
-                                new Constraint('>=', '1.0.0.0-dev'),
-                                new Constraint('<', '2.0.0.0-dev'),
-                            )
-                        ),
-                        new MultiConstraint(
-                            array(
-                                new Constraint('>=', '2.0.0.0-dev'),
-                                new Constraint('<', '3.0.0.0-dev'),
-                                new Constraint('!=', '2.0.1.0'),
-                            )
-                        ),
-                        new MultiConstraint(
-                            array(
-                                new Constraint('>=', '3.0.0.0-dev'),
-                                new Constraint('<', '5.0.0.0-dev'),
-                            )
-                        ),
-                    ),
-                    false // disjunctive
+                        new Constraint('>=', '1.0.0.0-dev'),
+                        new Constraint('<', '5.0.0.0-dev'),
+                        new Constraint('!=', '2.0.1.0'),
+                    )
+                ),
+            ),
+            'Test collapses multiple contiguous with multiple other constraint' => array(
+                '^1.0 != 1.0.1 || ^2.0 !=2.0.1 || ^3.0 || ^4.0 != 4.0.1',
+                new MultiConstraint(
+                    array(
+                        new Constraint('>=', '1.0.0.0-dev'),
+                        new Constraint('<', '5.0.0.0-dev'),
+                        new Constraint('!=', '1.0.1.0'),
+                        new Constraint('!=', '2.0.1.0'),
+                        new Constraint('!=', '4.0.1.0'),
+                    )
+                ),
+            ),
+            'Test collapse if contiguous range and other constraints also apply' => array(
+                '~0.1 || ~1.0 !=1.0.1',
+                new MultiConstraint(
+                    array(
+                        new Constraint('>=', '0.1.0.0-dev'),
+                        new Constraint('<', '2.0.0.0-dev'),
+                        new Constraint('!=', '1.0.1.0'),
+                    )
                 ),
             ),
             'Parse caret constraints must not collapse if non contiguous range' => array(
@@ -340,28 +345,7 @@ class MultiConstraintTest extends TestCase
                     false // disjunctive
                 ),
             ),
-            'Must not collapse if contiguous range if other constraints also apply' => array(
-                '~0.1 || ~1.0 !=1.0.1',
-                new MultiConstraint(
-                    array(
-                        new MultiConstraint(
-                            array(
-                                new Constraint('>=', '0.1.0.0-dev'),
-                                new Constraint('<', '1.0.0.0-dev'),
-                            )
-                        ),
-                        new MultiConstraint(
-                            array(
-                                new Constraint('>=', '1.0.0.0-dev'),
-                                new Constraint('<', '2.0.0.0-dev'),
-                                new Constraint('!=', '1.0.1.0'),
-                            )
-                        ),
-                    ),
-                    false // disjunctive
-                ),
-            ),
-            'Must not collapse contiguous range but merge following constraints' => array(
+            'Must not collapse if not contiguous range but collapse following constraints' => array(
                 '^0.1 || ^1.0 || ^2.0',
                 new MultiConstraint(
                     array(
@@ -381,34 +365,7 @@ class MultiConstraintTest extends TestCase
                     false // disjunctive
                 ),
             ),
-            'Must not collapse if other constraints also apply in one of intermediate range' => array(
-                '^1.0 || ^2.0 !=2.0.1 || ^3.0',
-                new MultiConstraint(
-                    array(
-                        new MultiConstraint(
-                            array(
-                                new Constraint('>=', '1.0.0.0-dev'),
-                                new Constraint('<', '2.0.0.0-dev'),
-                            )
-                        ),
-                        new MultiConstraint(
-                            array(
-                                new Constraint('>=', '2.0.0.0-dev'),
-                                new Constraint('<', '3.0.0.0-dev'),
-                                new Constraint('!=', '2.0.1.0'),
-                            )
-                        ),
-                        new MultiConstraint(
-                            array(
-                                new Constraint('>=', '3.0.0.0-dev'),
-                                new Constraint('<', '4.0.0.0-dev'),
-                            )
-                        ),
-                    ),
-                    false // disjunctive
-                ),
-            ),
-            'Must ignore not MultiConstraint' => array(
+            'Must not collapse other constraint not in range' => array(
                 '^1.0 || 2.1 || ^3.0',
                 new MultiConstraint(
                     array(

--- a/tests/Constraint/MultiConstraintTest.php
+++ b/tests/Constraint/MultiConstraintTest.php
@@ -283,6 +283,43 @@ class MultiConstraintTest extends TestCase
                     true // conjunctive
                 ),
             ),
+            'Test collapses multiple contiguous' => array(
+                '^2.5 || ^3.0 || ^4.0',
+                new MultiConstraint(
+                    array(
+                        new Constraint('>=', '2.5.0.0-dev'),
+                        new Constraint('<', '5.0.0.0-dev'),
+                    ),
+                    true // conjunctive
+                ),
+            ),
+            'Test collapses multiple contiguous with intermediate range' => array(
+                '^1.0 || ^2.0 !=2.0.1 || ^3.0 || ^4.0',
+                new MultiConstraint(
+                    array(
+                        new MultiConstraint(
+                            array(
+                                new Constraint('>=', '1.0.0.0-dev'),
+                                new Constraint('<', '2.0.0.0-dev'),
+                            )
+                        ),
+                        new MultiConstraint(
+                            array(
+                                new Constraint('>=', '2.0.0.0-dev'),
+                                new Constraint('<', '3.0.0.0-dev'),
+                                new Constraint('!=', '2.0.1.0'),
+                            )
+                        ),
+                        new MultiConstraint(
+                            array(
+                                new Constraint('>=', '3.0.0.0-dev'),
+                                new Constraint('<', '5.0.0.0-dev'),
+                            )
+                        ),
+                    ),
+                    false // disjunctive
+                ),
+            ),
             'Parse caret constraints must not collapse if non contiguous range' => array(
                 '^0.2 || ^1.0',
                 new MultiConstraint(
@@ -318,6 +355,54 @@ class MultiConstraintTest extends TestCase
                                 new Constraint('>=', '1.0.0.0-dev'),
                                 new Constraint('<', '2.0.0.0-dev'),
                                 new Constraint('!=', '1.0.1.0'),
+                            )
+                        ),
+                    ),
+                    false // disjunctive
+                ),
+            ),
+            'Must not collapse if other constraints also apply in one of intermediate range' => array(
+                '^1.0 || ^2.0 !=2.0.1 || ^3.0',
+                new MultiConstraint(
+                    array(
+                        new MultiConstraint(
+                            array(
+                                new Constraint('>=', '1.0.0.0-dev'),
+                                new Constraint('<', '2.0.0.0-dev'),
+                            )
+                        ),
+                        new MultiConstraint(
+                            array(
+                                new Constraint('>=', '2.0.0.0-dev'),
+                                new Constraint('<', '3.0.0.0-dev'),
+                                new Constraint('!=', '2.0.1.0'),
+                            )
+                        ),
+                        new MultiConstraint(
+                            array(
+                                new Constraint('>=', '3.0.0.0-dev'),
+                                new Constraint('<', '4.0.0.0-dev'),
+                            )
+                        ),
+                    ),
+                    false // disjunctive
+                ),
+            ),
+            'Must ignore not MultiConstraint' => array(
+                '^1.0 || 2.1 || ^3.0',
+                new MultiConstraint(
+                    array(
+                        new MultiConstraint(
+                            array(
+                                new Constraint('>=', '1.0.0.0-dev'),
+                                new Constraint('<', '2.0.0.0-dev'),
+                            )
+                        ),
+                        new Constraint('=', '2.1.0.0'),
+                        new MultiConstraint(
+                            array(
+                                new Constraint('>=', '3.0.0.0-dev'),
+                                new Constraint('<', '4.0.0.0-dev'),
                             )
                         ),
                     ),

--- a/tests/Constraint/MultiConstraintTest.php
+++ b/tests/Constraint/MultiConstraintTest.php
@@ -361,6 +361,26 @@ class MultiConstraintTest extends TestCase
                     false // disjunctive
                 ),
             ),
+            'Must not collapse contiguous range but merge following constraints' => array(
+                '^0.1 || ^1.0 || ^2.0',
+                new MultiConstraint(
+                    array(
+                        new MultiConstraint(
+                            array(
+                                new Constraint('>=', '0.1.0.0-dev'),
+                                new Constraint('<', '0.2.0.0-dev'),
+                            )
+                        ),
+                        new MultiConstraint(
+                            array(
+                                new Constraint('>=', '1.0.0.0-dev'),
+                                new Constraint('<', '3.0.0.0-dev'),
+                            )
+                        ),
+                    ),
+                    false // disjunctive
+                ),
+            ),
             'Must not collapse if other constraints also apply in one of intermediate range' => array(
                 '^1.0 || ^2.0 !=2.0.1 || ^3.0',
                 new MultiConstraint(


### PR DESCRIPTION
This PR optimize the MultiConstraint by alowing more than 2 constraints:

`^1.0 || ^2.0 || ^3.0` => `>= 1.0 <4.0`

It also replace calls to `MultiConstraint` methods by accessing private properties (allowed because same class)