### PR TITLE
Fix version comparison with branch alias

### DIFF
--- a/src/Constraint/Constraint.php
+++ b/src/Constraint/Constraint.php
@@ -203,7 +203,7 @@ class Constraint implements ConstraintInterface
         if ($this->versionCompare($provider->version, $this->version, self::$transOpInt[$this->operator], $compareBranches)) {
             // special case, e.g. require >= 1.0 and provide < 1.0
             // 1.0 >= 1.0 but 1.0 is outside of the provided interval
-            return !($provider->version === $this->version
+            return !(\version_compare($provider->version, $this->version, '==')
                 && self::$transOpInt[$provider->operator] === $providerNoEqualOp
                 && self::$transOpInt[$this->operator] !== $noEqualOp);
         }

--- a/tests/Constraint/ConstraintTest.php
+++ b/tests/Constraint/ConstraintTest.php
@@ -104,6 +104,7 @@ class ConstraintTest extends TestCase
             array('<=', '1', '>=', '2'),
             array('>=', '2', '<=', '1'),
             array('==', '2', '<', '2'),
+            array('==', '2.0-b2', '<', '2.0-beta2'),
             array('!=', '1', '==', '1'),
             array('==', '1', '!=', '1'),
             array('==', 'dev-foo-dist', '==', 'dev-foo-zist'),


### PR DESCRIPTION
This fix comparison of `=2.0-b2 & <2.0-beta2`

Result should be identical than `=2.0-b2 & <2.0-b2` (branch names are slightly different)