### PR TITLE
Fix invalid compilation code

### DIFF
--- a/src/Constraint/MultiConstraint.php
+++ b/src/Constraint/MultiConstraint.php
@@ -99,6 +99,10 @@ class MultiConstraint implements CompilableConstraintInterface
             }
         }
 
+        if (!$parts) {
+            return $this->conjunctive ? 'true' : 'false';
+        }
+
         return $this->conjunctive ? implode('&&', $parts) : implode('||', $parts);
     }
 

--- a/tests/Constraint/MultiConstraintTest.php
+++ b/tests/Constraint/MultiConstraintTest.php
@@ -391,6 +391,30 @@ class MultiConstraintTest extends TestCase
         );
     }
 
+    public function testMultiConstraintNotconjunctiveFillWithFalse()
+    {
+        $versionProvide = new Constraint('==', '1.1');
+        $multiRequire = new MultiConstraint(array(
+            new Constraint('!=', 'dev-foo'), // always false
+            new Constraint('!=', 'dev-bar'), // always false
+        ), false);
+
+        $this->assertFalse($multiRequire->matches($versionProvide));
+        $this->assertFalse($this->matchCompiled($multiRequire, '==', 1.1));
+    }
+
+    public function testMultiConstraintConjunctiveFillWithTrue()
+    {
+        $versionProvide = new Constraint('!=', '1.1');
+        $multiRequire = new MultiConstraint(array(
+            new Constraint('!=', 'dev-foo'), // always true
+            new Constraint('!=', 'dev-bar'), // always true
+        ), true);
+
+        $this->assertTrue($multiRequire->matches($versionProvide));
+        $this->assertTrue($this->matchCompiled($multiRequire, '!=', 1.1));
+    }
+
     private function matchCompiled(CompilableConstraintInterface $constraint, $operator, $version)
     {
         $map = array(


### PR DESCRIPTION
In some case, compilation return always `true` or `false`. The MultiConstrain compiler optimize it by removing `&& true` and `|| false`. 
But if all constraints are ignored the compiler returns an empty string. This PR fix it. 