### PR TITLE
Replace useless method call

### DIFF
--- a/src/Constraint/Bound.php
+++ b/src/Constraint/Bound.php
@@ -51,12 +51,12 @@ class Bound
 
     public function isZero()
     {
-        return $this->getVersion() === '0' && $this->isInclusive();
+        return $this->isInclusive && $this->version === '0';
     }
 
     public function isPositiveInfinity()
     {
-        return $this->getVersion() === (string) PHP_INT_MAX && !$this->isInclusive();
+        return !$this->isInclusive && $this->version === (string) PHP_INT_MAX;
     }
 
     /**
@@ -69,7 +69,7 @@ class Bound
      */
     public function compareTo(Bound $other, $operator)
     {
-        if (!\in_array($operator, array('<', '>'), true)) {
+        if ($operator !== '<' && $operator !== '>') {
             throw new \InvalidArgumentException('Does not support any other operator other than > or <.');
         }
 
@@ -78,7 +78,7 @@ class Bound
             return false;
         }
 
-        $compareResult = version_compare($this->getVersion(), $other->getVersion());
+        $compareResult = version_compare($this->version, $other->version);
 
         // Not the same version means we don't need to check if the bounds are inclusive or not
         if (0 !== $compareResult) {
@@ -86,15 +86,15 @@ class Bound
         }
 
         // Question we're answering here is "am I higher than $other?"
-        return '>' === $operator ? $other->isInclusive() : !$other->isInclusive();
+        return '>' === $operator ? $other->isInclusive : !$other->isInclusive;
     }
 
     public function __toString()
     {
         return sprintf(
             '%s [%s]',
-            $this->getVersion(),
-            $this->isInclusive() ? 'inclusive' : 'exclusive'
+            $this->version,
+            $this->isInclusive ? 'inclusive' : 'exclusive'
         );
     }
 

--- a/src/Constraint/Constraint.php
+++ b/src/Constraint/Constraint.php
@@ -289,7 +289,9 @@ class Constraint implements CompilableConstraintInterface
      */
     public function getLowerBound()
     {
-        $this->extractBounds();
+        if (null === $this->lowerBound) {
+            $this->extractBounds();
+        }
 
         return $this->lowerBound;
     }
@@ -299,17 +301,15 @@ class Constraint implements CompilableConstraintInterface
      */
     public function getUpperBound()
     {
-        $this->extractBounds();
+        if (null === $this->upperBound) {
+            $this->extractBounds();
+        }
 
         return $this->upperBound;
     }
 
     private function extractBounds()
     {
-        if (null !== $this->lowerBound) {
-            return;
-        }
-
         // Branches
         if (strpos($this->version, 'dev-') === 0) {
             $this->lowerBound = Bound::zero();

--- a/src/Constraint/MultiConstraint.php
+++ b/src/Constraint/MultiConstraint.php
@@ -170,7 +170,9 @@ class MultiConstraint implements CompilableConstraintInterface
      */
     public function getLowerBound()
     {
-        $this->extractBounds();
+        if (null === $this->lowerBound) {
+            $this->extractBounds();
+        }
 
         return $this->lowerBound;
     }
@@ -180,7 +182,9 @@ class MultiConstraint implements CompilableConstraintInterface
      */
     public function getUpperBound()
     {
-        $this->extractBounds();
+        if (null === $this->upperBound) {
+            $this->extractBounds();
+        }
 
         return $this->upperBound;
     }
@@ -275,10 +279,6 @@ class MultiConstraint implements CompilableConstraintInterface
 
     private function extractBounds()
     {
-        if (null !== $this->lowerBound) {
-            return;
-        }
-
         foreach ($this->constraints as $constraint) {
             if (null === $this->lowerBound && null === $this->upperBound) {
                 $this->lowerBound = $constraint->getLowerBound();


### PR DESCRIPTION
Removes call to internal method by using properties directly.
Unless we called methods because expect this class to be extended.

Note: Not a huge difference (bounds are called "only" ~1000 times)