### PR TITLE
use `@phpstan` prefix instead of `@psalm`

### DIFF
--- a/src/CompilingMatcher.php
+++ b/src/CompilingMatcher.php
@@ -25,7 +25,7 @@ class CompilingMatcher
     private static $enabled = null;
 
     /**
-     * @psalm-var array<Constraint::OP_*, string>
+     * @phpstan-var array<Constraint::OP_*, string>
      */
     private static $transOpInt = array(
         Constraint::OP_EQ => '==',
@@ -41,7 +41,7 @@ class CompilingMatcher
      *
      * @param ConstraintInterface $constraint
      * @param int                 $operator
-     * @psalm-param Constraint::OP_*  $operator
+     * @phpstan-param Constraint::OP_*  $operator
      * @param string              $version
      *
      * @return mixed

--- a/src/Constraint/Constraint.php
+++ b/src/Constraint/Constraint.php
@@ -28,7 +28,7 @@ class Constraint implements CompilableConstraintInterface
      * Operator to integer translation table.
      *
      * @var array
-     * @psalm-var array<string, self::OP_*>
+     * @phpstan-var array<string, self::OP_*>
      */
     private static $transOpStr = array(
         '=' => self::OP_EQ,
@@ -45,7 +45,7 @@ class Constraint implements CompilableConstraintInterface
      * Integer to operator translation table.
      *
      * @var array
-     * @psalm-var array<self::OP_*, string>
+     * @phpstan-var array<self::OP_*, string>
      */
     private static $transOpInt = array(
         self::OP_EQ => '==',
@@ -58,7 +58,7 @@ class Constraint implements CompilableConstraintInterface
 
     /**
      * @var int
-     * @psalm-var self::OP_*
+     * @phpstan-var self::OP_*
      */
     protected $operator;
 


### PR DESCRIPTION
> we should use @phpstan- prefix here since this repo uses just PHPStan. The disadvantage of the @psalm- prefix is that if PHPStan finds something it cannot parse, it stays silent, but in case of @phpstan-, it will tell you that.

as requested by @ondrejmirtes in https://github.com/composer/semver/pull/98#discussion_r420565012