### PR TITLE
Exclude conflict constraint from base constraint

### DIFF
--- a/src/Intervals.php
+++ b/src/Intervals.php
@@ -478,4 +478,22 @@ class Intervals
             new Interval(new Constraint('>=', $constraint->getVersion()), new Constraint('<=', $constraint->getVersion())),
         ), 'branches' => Interval::noDev());
     }
+
+    /**
+     * @param ConstraintInterface $base
+     * @param ConstraintInterface $conflict
+     * @return ConstraintInterface
+     */
+    public static function excludeConflict(ConstraintInterface $base, ConstraintInterface $conflict)
+    {
+        if ($conflict instanceof MatchAllConstraint || $base instanceof MatchNoneConstraint) {
+            return new MatchNoneConstraint();
+        }
+
+        if ($conflict instanceof MatchNoneConstraint || !self::haveIntersections($base, $conflict)) {
+            return $base;
+        }
+
+        // @todo
+    }
 }


### PR DESCRIPTION
This is currently just a proposal. The method is not implemented yet.

In a step after this. I'll try to exclude conflicts early. As a start I need to exclude a conflict in a single constraint.
That's what this PR is about.

Is this method of interest without a need in composer (for now)?

I also need to do some more research if and how stability has to be considered. Especially when base and conflict constraints intersect with different stability levels. If someone has more insights please let me know.
