### PR TITLE
Add test to confirm ambiguous constraints are rejected

### DIFF
--- a/src/VersionParser.php
+++ b/src/VersionParser.php
@@ -318,7 +318,7 @@ class VersionParser
             return array(new MatchAllConstraint());
         }
 
-        $versionRegex = 'v?(\d++)(?:\.(\d++|[xX*]))?(?:\.(\d++|[xX*]))?(?:\.(\d++|[xX*]))?' . self::$modifierRegex . '(?:\+[^\s]+)?';
+        $versionRegex = 'v?(\d++)(?:\.(\d++|[xX]))?(?:\.(\d++|[xX]))?(?:\.(\d++|[xX]))?' . self::$modifierRegex . '(?:\+[^\s]+)?';
 
         // Tilde Range
         //
@@ -346,7 +346,7 @@ class VersionParser
 
             // make sure all Xs are converted to the 9999999 it represents
             for ($i = $position; $i >= 0; $i--) {
-                if ($matches[$i] === 'x' || $matches[$i] === 'X' || $matches[$i] === '*') {
+                if ($matches[$i] === 'x' || $matches[$i] === 'X') {
                     $matches[$i] = '9999999';
                 }
             }
@@ -388,7 +388,7 @@ class VersionParser
             }
 
             // support ^0.x resolving to 0.9999 - 1.0-dev
-            if ($position === 2 && ($matches[2] === 'x' || $matches[2] === 'X' || $matches[2] === '*')) {
+            if ($position === 2 && ($matches[2] === 'x' || $matches[2] === 'X')) {
                 $position = 1;
             }
 

--- a/tests/VersionParserTest.php
+++ b/tests/VersionParserTest.php
@@ -662,6 +662,7 @@ class VersionParserTest extends TestCase
             'leading operator/3' => array('|| ^1@dev'),
             'trailing operator' => array('^1@dev ||'),
             'trailing operator/2' => array('^1@dev ,'),
+            'ambiguous meaning' => array('^1.*'),
         );
     }
 

--- a/tests/VersionParserTest.php
+++ b/tests/VersionParserTest.php
@@ -663,6 +663,9 @@ class VersionParserTest extends TestCase
             'trailing operator' => array('^1@dev ||'),
             'trailing operator/2' => array('^1@dev ,'),
             'ambiguous meaning' => array('^1.*'),
+            'ambiguous meaning/2' => array('~1.*'),
+            'ambiguous meaning/3' => array('^1.0.*'),
+            'ambiguous meaning/4' => array('~1.0.*'),
         );
     }
 


### PR DESCRIPTION
https://getcomposer.org/doc/faqs/why-are-version-constraints-combining-comparisons-and-wildcards-a-bad-idea.md documents that these constraints should be rejected. 71404e64871484347d2e88955b0b1e16f5336ef1 is the commit that changed this behavior.

This PR is just the change to the tests to demonstrate that it is now allowing the invalid constraints.