### PR TITLE
Flip operation When matching a conjunctive and a disjunctive constraint

### DIFF
--- a/src/Constraint/MultiConstraint.php
+++ b/src/Constraint/MultiConstraint.php
@@ -120,7 +120,7 @@ class MultiConstraint implements ConstraintInterface
             return false;
         }
 
-        // when matching a conjunctive and a disjunctive mutli constraint we have to iterate over the disjunctive one
+        // when matching a conjunctive and a disjunctive multi constraint we have to iterate over the disjunctive one
         // otherwise we'd return true if different parts of the disjunctive constraint match the conjunctive one
         // which would lead to incorrect results, e.g. [>1 and <2] would match [<1 or >2] although they do not intersect
         if ($provider instanceof MultiConstraint && $provider->isDisjunctive()) {

--- a/src/Constraint/MultiConstraint.php
+++ b/src/Constraint/MultiConstraint.php
@@ -120,6 +120,13 @@ class MultiConstraint implements ConstraintInterface
             return false;
         }
 
+        // when matching a conjunctive and a disjunctive mutli constraint we have to iterate over the disjunctive one
+        // otherwise we'd return true if different parts of the disjunctive constraint match the conjunctive one
+        // which would lead to incorrect results, e.g. [>1 and <2] would match [<1 or >2] although they do not intersect
+        if ($provider instanceof MultiConstraint && $provider->isDisjunctive()) {
+            return $provider->matches($this);
+        }
+
         foreach ($this->constraints as $constraint) {
             if (!$provider->matches($constraint)) {
                 return false;

--- a/tests/Constraint/MultiConstraintTest.php
+++ b/tests/Constraint/MultiConstraintTest.php
@@ -90,6 +90,21 @@ class MultiConstraintTest extends TestCase
         $this->assertTrue(Intervals::compactConstraint($multiProvide)->matches(Intervals::compactConstraint($multiRequire)));
     }
 
+    public function testConjunctiveMatchesDisjunctiveFalse()
+    {
+        $versionProvideStart = new Constraint('<', '1.0');
+        $versionProvideEnd = new Constraint('>', '2.0');
+
+        $multiRequire = new MultiConstraint(array($this->versionRequireStart, $this->versionRequireEnd), true);
+        $multiProvide = new MultiConstraint(array($versionProvideStart, $versionProvideEnd), false);
+
+        $this->assertFalse($multiRequire->matches($multiProvide));
+        $this->assertFalse($multiProvide->matches($multiRequire));
+        $this->assertFalse(Intervals::haveIntersections($multiRequire, $multiProvide));
+        $this->assertFalse(Intervals::compactConstraint($multiRequire)->matches(Intervals::compactConstraint($multiProvide)));
+        $this->assertFalse(Intervals::compactConstraint($multiProvide)->matches(Intervals::compactConstraint($multiRequire)));
+    }
+
     public function testMultiVersionMatchFails()
     {
         $versionProvide = new Constraint('==', '1.2');


### PR DESCRIPTION
We need to iterate over the disjunctive constraint because the result is correct as long as one of the elements matches, iterating over the conjunctive constraint may result in incorrect matching to a disjunctive constraint.

Addresses https://github.com/composer/semver/issues/126

However will need to look at some more complex scenarios involving multiple levels of nesting of conjunctive and disjunctive multi constraints which I'm not sure about of the top of my head.

Alternatively we'd have to entirely switch to the safer and more correct interval implementation although it may be slower.