### PR TITLE
fix invalid syntax in phpdoc

### DIFF
--- a/src/Intervals.php
+++ b/src/Intervals.php
@@ -431,7 +431,7 @@ class Intervals
     }
 
     /**
-     * @phpstan-return array{'numeric': Interval[], 'branches': array{'names': string[], 'exclude': bool}}}
+     * @phpstan-return array{'numeric': Interval[], 'branches': array{'names': string[], 'exclude': bool}}
      */
     private static function generateSingleConstraintIntervals(Constraint $constraint)
     {


### PR DESCRIPTION
Hi,

This PR fixes an extraneous bracket at the end of a phpdoc line.

Related to https://github.com/vimeo/psalm/issues/7289