### PR TITLE
Fixed MultiConstraint with MatchAllConstraint

### DIFF
--- a/src/Constraint/MultiConstraint.php
+++ b/src/Constraint/MultiConstraint.php
@@ -207,9 +207,12 @@ class MultiConstraint implements ConstraintInterface
             return $constraints[0];
         }
 
-        foreach ($constraints as $constraint) {
+        foreach ($constraints as $k => $constraint) {
             if ($constraint instanceof MatchAllConstraint) {
-                return new MatchAllConstraint();
+                if (!$conjunctive) {
+                    return new MatchAllConstraint();
+                }
+                unset($constraints[$k]);
             }
         }
 

--- a/src/Constraint/MultiConstraint.php
+++ b/src/Constraint/MultiConstraint.php
@@ -207,6 +207,12 @@ class MultiConstraint implements ConstraintInterface
             return $constraints[0];
         }
 
+        foreach ($constraints as $constraint) {
+            if ($constraint instanceof MatchAllConstraint) {
+                return new MatchAllConstraint();
+            }
+        }
+
         $optimized = self::optimizeConstraints($constraints, $conjunctive);
         if ($optimized !== null) {
             list($constraints, $conjunctive) = $optimized;

--- a/tests/Constraint/MultiConstraintTest.php
+++ b/tests/Constraint/MultiConstraintTest.php
@@ -275,14 +275,14 @@ class MultiConstraintTest extends TestCase
         $this->assertInstanceOf('Composer\Semver\Constraint\MatchAllConstraint', MultiConstraint::create(array()));
     }
 
-    public function testCreatesMatchAllConstraintIfConjunctiveAndCombinedWithAnotherONe()
+    public function testRemovesMatchAllConstraintIfConjunctiveAndCombinedWithOtherConstraints()
     {
-        $this->assertInstanceOf('Composer\Semver\Constraint\MatchAllConstraint', MultiConstraint::create(
-            array(new Constraint('>=', '2.5.0.0-dev'), new MatchAllConstraint())
+        $this->assertSame('[>= 2.5.0.0-dev <= 3.0.0.0-dev]', (string) MultiConstraint::create(
+            array(new Constraint('>=', '2.5.0.0-dev'), new Constraint('<=', '3.0.0.0-dev'), new MatchAllConstraint())
         ));
     }
 
-    public function testCreatesMatchAllConstraintIfDisjunctiveAndCombinedWithAnotherONe()
+    public function testCreatesMatchAllConstraintIfDisjunctiveAndCombinedWithAnotherOne()
     {
         $this->assertInstanceOf('Composer\Semver\Constraint\MatchAllConstraint', MultiConstraint::create(
             array(new Constraint('>=', '2.5.0.0-dev'), new MatchAllConstraint()), false

--- a/tests/Constraint/MultiConstraintTest.php
+++ b/tests/Constraint/MultiConstraintTest.php
@@ -275,6 +275,20 @@ class MultiConstraintTest extends TestCase
         $this->assertInstanceOf('Composer\Semver\Constraint\MatchAllConstraint', MultiConstraint::create(array()));
     }
 
+    public function testCreatesMatchAllConstraintIfConjunctiveAndCombinedWithAnotherONe()
+    {
+        $this->assertInstanceOf('Composer\Semver\Constraint\MatchAllConstraint', MultiConstraint::create(
+            array(new Constraint('>=', '2.5.0.0-dev'), new MatchAllConstraint())
+        ));
+    }
+
+    public function testCreatesMatchAllConstraintIfDisjunctiveAndCombinedWithAnotherONe()
+    {
+        $this->assertInstanceOf('Composer\Semver\Constraint\MatchAllConstraint', MultiConstraint::create(
+            array(new Constraint('>=', '2.5.0.0-dev'), new MatchAllConstraint()), false
+        ));
+    }
+
     /**
      * @dataProvider multiConstraintOptimizations
      *


### PR DESCRIPTION
I'm not sure if this is correct but I'm fairly sure the current behaviour is incorrect :D 

If I create a `MultiConstraint` with any instance of `MatchAllConstraint`, I currently get a `MultiConstraint` back which seems strange.

`>= 2.5.0 AND *` should return either a `MatchAllConstraint` or a `MatchNonConstraint`. Same goes for `OR`. I'm just confused at the moment as to which one has to return what but I'm proposing it anyway :D 