### PR TITLE
Fix: Ignore PHPUnit result cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor/
 .php_cs.cache
+/.phpunit.result.cache
 composer.lock


### PR DESCRIPTION
This pull request

- [x] ignores the PHPUnit result cache file