### PR TITLE
Fixed VersionParser being unable to parse its own MultiConstraint format

### DIFF
--- a/src/VersionParser.php
+++ b/src/VersionParser.php
@@ -261,7 +261,7 @@ class VersionParser
         $orGroups = array();
 
         foreach ($orConstraints as $orConstraint) {
-            $andConstraints = preg_split('{(?<!^|as|[=>< ,]) *(?<!-)[, ](?!-) *(?!,|as|$)}', $orConstraint);
+            $andConstraints = preg_split('{(?<!^|as|[=>< ,]) *(?<!-)[, ](?!-) *(?!,|as|$)}', trim($orConstraint, '[]'));
             if (false === $andConstraints) {
                 throw new \RuntimeException('Failed to preg_split string: '.$orConstraint);
             }

--- a/tests/VersionParserTest.php
+++ b/tests/VersionParserTest.php
@@ -597,6 +597,7 @@ class VersionParserTest extends TestCase
         $multi = new MultiConstraint(array($first, $second));
 
         $this->assertSame((string) $multi, (string) $parser->parseConstraints($constraint));
+        $this->assertSame((string) $multi, (string) $parser->parseConstraints((string) $multi));
     }
 
     /**


### PR DESCRIPTION
The `VersionParser` currently cannot handle the output of `(string) $multiConstraint`. 

In my case, I had to merge multiple constraints and pass them on in a string representation. When you do that, the `MultiConstraint` will return something like this: `[>= 2.5.9.0-dev < 2.6.0.0-dev]`. But if you pass this to `VersionParser::parseConstraints()` you'll end up getting like `UnexpectedValueException: Could not parse version constraint [>= 2.5.9.0-dev: Invalid version string "[>= 2.5.9.0-dev"`.

It's pretty weird that the `VersionParser` cannot handle a format that was created by a class coming from the very same library - so I consider this a bug :) 

Not sure this is the right fix but tests are still  green, so at least tit doesn't break any current logic (and it also fixes my issue).