### PR TITLE
Add phpstan-baseline.neon to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,3 +16,4 @@
 /phpunit.xml.dist export-ignore
 /tests export-ignore
 /CONTRIBUTING.md export-ignore
+/phpstan-baseline.neon export-ignore


### PR DESCRIPTION
so not included on install