### PR TITLE
Fix: resolve PHP 8.3 deprecation in test suite

### DIFF
--- a/tests/SemverTest.php
+++ b/tests/SemverTest.php
@@ -66,7 +66,7 @@ class SemverTest extends TestCase
         $semver = new \ReflectionClass('\Composer\Semver\Semver');
         $versionParserProperty = $semver->getProperty('versionParser');
         $versionParserProperty->setAccessible(true);
-        $versionParserProperty->setValue(null);
+        $versionParserProperty->setValue(null, null);
 
         $manipulateVersionStringMethod = $semver->getMethod('usort');
         $manipulateVersionStringMethod->setAccessible(true);


### PR DESCRIPTION
Resolve the following deprecation when running the test suite with PHP 8.3:

    Remaining self deprecation notices (1)
      1x: Calling ReflectionProperty::setValue() with a single argument is deprecated
        1x in SemverTest::testUsortShouldInitialVersionParserClass from Composer\Semver