### PR TITLE
Prepare tests for PHPUnit 10

### DIFF
--- a/tests/Constraint/ConstraintTest.php
+++ b/tests/Constraint/ConstraintTest.php
@@ -25,7 +25,11 @@ class ConstraintTest extends TestCase
      */
     protected $versionProvide;
 
-    protected function setUp()
+    /**
+     * @before
+     * @return void
+     */
+    public function setUpTestCase()
     {
         $this->constraint = new Constraint('==', '1');
         $this->versionProvide = new Constraint('==', 'dev-foo');

--- a/tests/Constraint/ConstraintTest.php
+++ b/tests/Constraint/ConstraintTest.php
@@ -377,33 +377,29 @@ class ConstraintTest extends TestCase
     public function testInverseMatchingOtherConstraints()
     {
         $constraint = new Constraint('>', '1.0.0');
+        $otherConstraintClasses = array(
+            'Composer\Semver\Constraint\MultiConstraint',
+            'Composer\Semver\Constraint\MatchAllConstraint'
+        );
 
-        $multiConstraint = $this
-            ->getMockBuilder('Composer\Semver\Constraint\MultiConstraint')
-            ->disableOriginalConstructor()
-            ->setMethods(array('matches'))
-            ->getMock()
-        ;
-
-        $matchAllConstraint = $this
-            ->getMockBuilder('Composer\Semver\Constraint\MatchAllConstraint')
-            ->setMethods(array('matches'))
-            ->getMock()
-        ;
-
-        foreach (array($multiConstraint, $matchAllConstraint) as $mock) {
-            $mock
+        foreach ($otherConstraintClasses as $otherConstraintClass) {
+            $otherConstraintMockBuilder =  $this->getMockBuilder($otherConstraintClass);
+            $otherConstraintMockBuilder->disableOriginalConstructor();
+            if (method_exists($otherConstraintMockBuilder, 'onlyMethods')) {
+                $otherConstraintMockBuilder->onlyMethods(array('matches'));
+            } elseif (method_exists($otherConstraintMockBuilder, 'setMethods')) {
+                $otherConstraintMockBuilder->setMethods(array('matches'));
+            }
+            $otherConstraintMock = $otherConstraintMockBuilder->getMock();
+            $otherConstraintMock
                 ->expects($this->once())
                 ->method('matches')
                 ->with($constraint)
                 ->willReturn(true)
             ;
+            // @phpstan-ignore-next-line
+            $this->assertTrue($constraint->matches($otherConstraintMock));
         }
-
-        // @phpstan-ignore-next-line
-        $this->assertTrue($constraint->matches($multiConstraint));
-        // @phpstan-ignore-next-line
-        $this->assertTrue($constraint->matches($matchAllConstraint));
     }
 
     public function testComparableBranches()

--- a/tests/Constraint/MatchAllConstraintTest.php
+++ b/tests/Constraint/MatchAllConstraintTest.php
@@ -24,7 +24,11 @@ class MatchAllConstraintTest extends TestCase
      */
     protected $matchAllConstraint;
 
-    protected function setUp()
+    /**
+     * @before
+     * @return void
+     */
+    public function setUpTestCase()
     {
         $this->versionProvide = new Constraint('==', '1.1');
         $this->matchAllConstraint = new MatchAllConstraint();

--- a/tests/Constraint/MatchNoneConstraintTest.php
+++ b/tests/Constraint/MatchNoneConstraintTest.php
@@ -20,7 +20,11 @@ class MatchNoneConstraintTest extends TestCase
      */
     protected $matchNoneConstraint;
 
-    protected function setUp()
+    /**
+     * @before
+     * @return void
+     */
+    public function setUpTestCase()
     {
         $this->matchNoneConstraint = new MatchNoneConstraint();
     }

--- a/tests/Constraint/MultiConstraintTest.php
+++ b/tests/Constraint/MultiConstraintTest.php
@@ -26,7 +26,11 @@ class MultiConstraintTest extends TestCase
      */
     protected $versionRequireEnd;
 
-    protected function setUp()
+    /**
+     * @before
+     * @return void
+     */
+    public function setUpTestCase()
     {
         $this->versionRequireStart = new Constraint('>', '1.0');
         $this->versionRequireEnd = new Constraint('<', '1.2');


### PR DESCRIPTION
Prepare test classes for use with PHPUnit 10 while maintaining compatibility with older versions of PHPUnit:
* Use `onlyMethods` instead of `setMethods` on `MockBuilder` instance when available, as `setMethods` has been removed in PHPUnit 10.
* Avoid mandatory `void` return type of the inherited `setUp` method in PHPUnit 10.
* ~Mark all data providers as static as non-static data providers are deprecated in PHPUnit 10~ (this is already merged via #163).

Note that the `symfony/phpunit-bridge` package [does not support PHPunit 10](https://github.com/symfony/symfony/issues/49069#issuecomment-1966560507). So in order to run the test suite with this version, the 10.x version of the tool should be installed as a PHAR or via Composer (`composer require --dev phpunit/phpunit:~10.5`).