### PR TITLE
Mark all data providers in test suite as static

### DIFF
--- a/tests/ComparatorTest.php
+++ b/tests/ComparatorTest.php
@@ -128,7 +128,7 @@ class ComparatorTest extends TestCase
     /**
      * @return array<mixed>
      */
-    public function greaterThanProvider()
+    public static function greaterThanProvider()
     {
         return array(
             array('1.25.0', '1.24.0', true),
@@ -143,7 +143,7 @@ class ComparatorTest extends TestCase
     /**
      * @return array<mixed>
      */
-    public function greaterThanOrEqualToProvider()
+    public static function greaterThanOrEqualToProvider()
     {
         return array(
             array('1.25.0', '1.24.0', true),
@@ -155,7 +155,7 @@ class ComparatorTest extends TestCase
     /**
      * @return array<mixed>
      */
-    public function lessThanProvider()
+    public static function lessThanProvider()
     {
         return array(
             array('1.25.0', '1.24.0', false),
@@ -171,7 +171,7 @@ class ComparatorTest extends TestCase
     /**
      * @return array<mixed>
      */
-    public function lessThanOrEqualToProvider()
+    public static function lessThanOrEqualToProvider()
     {
         return array(
             array('1.25.0', '1.24.0', false),
@@ -183,7 +183,7 @@ class ComparatorTest extends TestCase
     /**
      * @return array<mixed>
      */
-    public function equalToProvider()
+    public static function equalToProvider()
     {
         return array(
             array('1.25.0', '1.24.0', false),
@@ -198,7 +198,7 @@ class ComparatorTest extends TestCase
     /**
      * @return array<mixed>
      */
-    public function notEqualToProvider()
+    public static function notEqualToProvider()
     {
         return array(
             array('1.25.0', '1.24.0', true),
@@ -210,7 +210,7 @@ class ComparatorTest extends TestCase
     /**
      * @return array<mixed>
      */
-    public function compareProvider()
+    public static function compareProvider()
     {
         return array(
             array('1.25.0', '>', '1.24.0', true),

--- a/tests/Constraint/ConstraintTest.php
+++ b/tests/Constraint/ConstraintTest.php
@@ -438,7 +438,7 @@ class ConstraintTest extends TestCase
     /**
      * @return array<mixed>
      */
-    public function invalidOperators()
+    public static function invalidOperators()
     {
         return array(
             array('1.2.3', 'invalid', 'InvalidArgumentException'),
@@ -466,7 +466,7 @@ class ConstraintTest extends TestCase
     /**
      * @return array<mixed>
      */
-    public function bounds()
+    public static function bounds()
     {
         return array(
             'equal to 1.0.0.0' => array('==', '1.0.0.0', new Bound('1.0.0.0', true), new Bound('1.0.0.0', true)),
@@ -535,7 +535,7 @@ class ConstraintTest extends TestCase
     /**
      * @return array<mixed>
      */
-    public function matrix()
+    public static function matrix()
     {
         $versions = array('1.0', '2.0', 'dev-master', 'dev-foo', '3.0-b2', '3.0-beta2');
         $operators = array('==', '!=', '>', '<', '>=', '<=');

--- a/tests/Constraint/MultiConstraintTest.php
+++ b/tests/Constraint/MultiConstraintTest.php
@@ -154,7 +154,7 @@ class MultiConstraintTest extends TestCase
     /**
      * @return array<mixed>
      */
-    public function bounds()
+    public static function bounds()
     {
         return array(
             'all equal' => array(
@@ -226,7 +226,7 @@ class MultiConstraintTest extends TestCase
     /**
      * @return array<mixed>
      */
-    public function boundsIntegration()
+    public static function boundsIntegration()
     {
         return array(
             '^7.0' => array(
@@ -321,7 +321,7 @@ class MultiConstraintTest extends TestCase
     /**
      * @return array<mixed>
      */
-    public function multiConstraintOptimizations()
+    public static function multiConstraintOptimizations()
     {
         return array(
             'Test collapses contiguous' => array(

--- a/tests/IntervalsTest.php
+++ b/tests/IntervalsTest.php
@@ -51,7 +51,7 @@ class IntervalsTest extends TestCase
         $this->assertSame((string) $expected, (string) $new);
     }
 
-    public function compactProvider()
+    public static function compactProvider()
     {
         return array(
             'simple disjunctive multi' => array(
@@ -238,7 +238,7 @@ class IntervalsTest extends TestCase
         $this->assertSame($expected, $result);
     }
 
-    public function intervalsProvider()
+    public static function intervalsProvider()
     {
         return array(
             'simple case' => array(

--- a/tests/SemverTest.php
+++ b/tests/SemverTest.php
@@ -79,7 +79,7 @@ class SemverTest extends TestCase
     /**
      * @return array<mixed>
      */
-    public function sortProvider()
+    public static function sortProvider()
     {
         return array(
             array(
@@ -98,19 +98,19 @@ class SemverTest extends TestCase
     /**
      * @return array<mixed>
      */
-    public function satisfiesProvider()
+    public static function satisfiesProvider()
     {
         $positive = array_map(function ($array) {
             array_unshift($array, true);
 
             return $array;
-        }, $this->satisfiesProviderPositive());
+        }, static::satisfiesProviderPositive());
 
         $negative = array_map(function ($array) {
             array_unshift($array, false);
 
             return $array;
-        }, $this->satisfiesProviderNegative());
+        }, static::satisfiesProviderNegative());
 
         return array_merge($positive, $negative);
     }
@@ -118,7 +118,7 @@ class SemverTest extends TestCase
     /**
      * @return array<mixed>
      */
-    public function satisfiesProviderPositive()
+    public static function satisfiesProviderPositive()
     {
         return array(
             array('1.2.3', '1.0.0 - 2.0.0'),
@@ -200,7 +200,7 @@ class SemverTest extends TestCase
     /**
      * @return array<mixed>
      */
-    public function satisfiesProviderNegative()
+    public static function satisfiesProviderNegative()
     {
         return array(
             array('2.2.3', '1.0.0 - 2.0.0'),
@@ -254,7 +254,7 @@ class SemverTest extends TestCase
     /**
      * @return array<mixed>
      */
-    public function satisfiedByProvider()
+    public static function satisfiedByProvider()
     {
         return array(
             array(

--- a/tests/SubsetsTest.php
+++ b/tests/SubsetsTest.php
@@ -34,7 +34,7 @@ class SubsetsTest extends TestCase
     /**
      * @return array<mixed>
      */
-    public function subsets()
+    public static function subsets()
     {
         return array(
             // x is subset of y
@@ -101,7 +101,7 @@ class SubsetsTest extends TestCase
     /**
      * @return array<mixed>
      */
-    public function notSubsets()
+    public static function notSubsets()
     {
         return array(
             // x is subset of y

--- a/tests/VersionParserTest.php
+++ b/tests/VersionParserTest.php
@@ -33,7 +33,7 @@ class VersionParserTest extends TestCase
     /**
      * @return array<mixed>
      */
-    public function numericAliasVersions()
+    public static function numericAliasVersions()
     {
         return array(
             array('0.x-dev', '0.'),
@@ -62,7 +62,7 @@ class VersionParserTest extends TestCase
     /**
      * @return array<mixed>
      */
-    public function successfulNormalizedVersions()
+    public static function successfulNormalizedVersions()
     {
         return array(
             'none' => array('1.0.0', '1.0.0.0'),
@@ -157,7 +157,7 @@ class VersionParserTest extends TestCase
     /**
      * @return array<mixed>
      */
-    public function failingNormalizedVersions()
+    public static function failingNormalizedVersions()
     {
         return array(
             'empty ' => array(''),
@@ -208,7 +208,7 @@ class VersionParserTest extends TestCase
     /**
      * @return array<mixed>
      */
-    public function failingNormalizedVersionsWithBadAlias()
+    public static function failingNormalizedVersionsWithBadAlias()
     {
         return array(
             'Alias and caret' => array('1.0.0+foo as ^2.0'),
@@ -238,7 +238,7 @@ class VersionParserTest extends TestCase
     /**
      * @return array<mixed>
      */
-    public function failingNormalizedVersionsWithBadAliasee()
+    public static function failingNormalizedVersionsWithBadAliasee()
     {
         return array(
             'Alias and caret' => array('^2.0 as 1.0.0+foo'),
@@ -264,7 +264,7 @@ class VersionParserTest extends TestCase
     /**
      * @return array<mixed>
      */
-    public function successfulNormalizedBranches()
+    public static function successfulNormalizedBranches()
     {
         return array(
             'parses x' => array('v1.x', '1.9999999.9999999.9999999-dev'),
@@ -333,7 +333,7 @@ class VersionParserTest extends TestCase
     /**
      * @return array<mixed>
      */
-    public function simpleConstraints()
+    public static function simpleConstraints()
     {
         return array(
             'match any' => array('*', new MatchAllConstraint()),
@@ -392,7 +392,7 @@ class VersionParserTest extends TestCase
     /**
      * @return array<mixed>
      */
-    public function wildcardConstraints()
+    public static function wildcardConstraints()
     {
         return array(
             array('v2.*', new Constraint('>=', '2.0.0.0-dev'), new Constraint('<', '3.0.0.0-dev')),
@@ -434,7 +434,7 @@ class VersionParserTest extends TestCase
     /**
      * @return array<mixed>
      */
-    public function tildeConstraints()
+    public static function tildeConstraints()
     {
         return array(
             array('~v1', new Constraint('>=', '1.0.0.0-dev'), new Constraint('<', '2.0.0.0-dev')),
@@ -481,7 +481,7 @@ class VersionParserTest extends TestCase
     /**
      * @return array<mixed>
      */
-    public function caretConstraints()
+    public static function caretConstraints()
     {
         return array(
             array('^v1', new Constraint('>=', '1.0.0.0-dev'), new Constraint('<', '2.0.0.0-dev')),
@@ -531,7 +531,7 @@ class VersionParserTest extends TestCase
     /**
      * @return array<mixed>
      */
-    public function hyphenConstraints()
+    public static function hyphenConstraints()
     {
         return array(
             array('v1 - v2', new Constraint('>=', '1.0.0.0-dev'), new Constraint('<', '3.0.0.0-dev')),
@@ -566,7 +566,7 @@ class VersionParserTest extends TestCase
     /**
      * @return array<mixed>
      */
-    public function constraintProvider()
+    public static function constraintProvider()
     {
         return array(
             // numeric branch
@@ -618,7 +618,7 @@ class VersionParserTest extends TestCase
     /**
      * @return array<mixed>
      */
-    public function multiConstraintProvider()
+    public static function multiConstraintProvider()
     {
         return array(
             array('>2.0,<=3.0'),
@@ -670,7 +670,7 @@ class VersionParserTest extends TestCase
     /**
      * @return array<mixed>
      */
-    public function multiConstraintProvider2()
+    public static function multiConstraintProvider2()
     {
         return array(
             array('>2.0,<2.0.5 | >2.0.6'),
@@ -724,7 +724,7 @@ class VersionParserTest extends TestCase
     /**
      * @return array<mixed>
      */
-    public function failingConstraints()
+    public static function failingConstraints()
     {
         return array(
             'empty ' => array(''),
@@ -783,7 +783,7 @@ class VersionParserTest extends TestCase
     /**
      * @return array<mixed>
      */
-    public function stabilityProvider()
+    public static function stabilityProvider()
     {
         return array(
             array('stable', '1'),


### PR DESCRIPTION
Reasons:
- consistency: some data providers were already static, now all of them are static
- performance: the class does not need to be instantiated anymore to execute the data provider
- future-proof: non-static data providers are deprecated in PHPUnit 10

Cherry-picked from PR #162.