### PR TITLE
Add PHP 8.3 to GitHub workflows

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -29,6 +29,7 @@ jobs:
           - "8.0"
           - "8.1"
           - "8.2"
+          - "8.3"
 
     steps:
       - name: "Checkout"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,6 +15,7 @@ jobs:
         php-version:
           - "5.3"
           - "7.4"
+          - "8.3"
 
     steps:
       - name: "Checkout"

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -16,8 +16,11 @@ jobs:
 
     strategy:
       matrix:
-        php-version:
-          - "7.4"
+        include:
+          - php-version: "7.4"
+            phpunit-version-constraint: "^7.5"
+          - php-version: "8.3"
+            phpunit-version-constraint: "^9.6"
 
     steps:
       - name: "Checkout"
@@ -44,7 +47,6 @@ jobs:
         run: "composer update ${{ env.COMPOSER_FLAGS }}"
 
       - name: Run PHPStan
-        # Locked to phpunit 7.5 here as newer ones have void return types which break inheritance
         run: |
-          composer require --dev phpunit/phpunit:^7.5.20 --with-all-dependencies ${{ env.COMPOSER_FLAGS }}
+          composer require --dev phpunit/phpunit:"${{ matrix.phpunit-version-constraint }}" --with-all-dependencies ${{ env.COMPOSER_FLAGS }}
           vendor/bin/phpstan analyse

--- a/tests/Constraint/ConstraintTest.php
+++ b/tests/Constraint/ConstraintTest.php
@@ -11,6 +11,8 @@
 
 namespace Composer\Semver\Constraint;
 
+use Exception;
+use LogicException;
 use PHPUnit\Framework\TestCase;
 use Composer\Semver\Intervals;
 
@@ -397,7 +399,7 @@ class ConstraintTest extends TestCase
                 ->with($constraint)
                 ->willReturn(true)
             ;
-            // @phpstan-ignore-next-line
+            /** @var ConstraintInterface $otherConstraintMock */
             $this->assertTrue($constraint->matches($otherConstraintMock));
         }
     }
@@ -426,7 +428,7 @@ class ConstraintTest extends TestCase
      *
      * @param string $version
      * @param Constraint::STR_OP_* $operator
-     * @param class-string $expected
+     * @param class-string<Exception> $expected
      */
     public function testInvalidOperators($version, $operator, $expected)
     {
@@ -580,16 +582,17 @@ class ConstraintTest extends TestCase
     }
 
     /**
-     * @param  class-string $class
+     * @param  class-string<Exception> $class
      * @return void
      */
     private function doExpectException($class)
     {
         if (method_exists($this, 'expectException')) {
             $this->expectException($class);
-        } else {
-            // @phpstan-ignore-next-line
+        } elseif (method_exists($this, 'setExpectedException')) {
             $this->setExpectedException($class);
+        } else {
+            throw new LogicException('Expected method "expectException" or "setExpectedException" to exist.');
         }
     }
 }

--- a/tests/VersionParserTest.php
+++ b/tests/VersionParserTest.php
@@ -14,6 +14,8 @@ namespace Composer\Semver;
 use Composer\Semver\Constraint\MatchAllConstraint;
 use Composer\Semver\Constraint\MultiConstraint;
 use Composer\Semver\Constraint\Constraint;
+use Exception;
+use LogicException;
 use PHPUnit\Framework\TestCase;
 
 class VersionParserTest extends TestCase
@@ -851,7 +853,7 @@ class VersionParserTest extends TestCase
     }
 
     /**
-     * @param class-string $class
+     * @param class-string<Exception> $class
      * @param string|null $message
      * @return void
      */
@@ -862,9 +864,10 @@ class VersionParserTest extends TestCase
             if ($message) {
                 $this->expectExceptionMessage($message);
             }
-        } else {
-            // @phpstan-ignore-next-line
+        } elseif (method_exists($this, 'setExpectedException')) {
             $this->setExpectedException($class, $message);
+        } else {
+            throw new LogicException('Expected method "expectException" or "setExpectedException" to exist.');
         }
     }
 }


### PR DESCRIPTION
This PR adds PHP 8.3 to the GitHub workflows for linting, continuous integration and PHPStan.

PHPStan reported a number of violations regarding the test suite with PHP 8.3 and PHPUnit 9.6, which been resolved.