### PR TITLE
Normalize `main` without `dev-` prefix

### DIFF
--- a/src/VersionParser.php
+++ b/src/VersionParser.php
@@ -139,8 +139,8 @@ class VersionParser
             $version = substr($version, 0, strlen($version) - strlen($match[0]));
         }
 
-        // normalize master/trunk/default branches to dev-name for BC with 1.x as these used to be valid constraints
-        if (\in_array($version, array('master', 'trunk', 'default'), true)) {
+        // normalize master/main/trunk/default branches to dev-name for BC with 1.x as these used to be valid constraints
+        if (\in_array($version, array('master', 'main', 'trunk', 'default'), true)) {
             $version = 'dev-' . $version;
         }
 

--- a/tests/VersionParserTest.php
+++ b/tests/VersionParserTest.php
@@ -140,6 +140,8 @@ class VersionParserTest extends TestCase
             'parses dt Ym+patch' => array('201903.0-p2', '201903.0-patch2'),
             'parses master' => array('dev-master', 'dev-master'),
             'parses master w/o dev' => array('master', 'dev-master'),
+            'parses main' => array('dev-main', 'dev-main'),
+            'parses main w/o dev' => array('main', 'dev-main'),
             'parses trunk' => array('dev-trunk', 'dev-trunk'),
             'parses branches' => array('1.x-dev', '1.9999999.9999999.9999999-dev'),
             'parses arbitrary' => array('dev-feature-foo', 'dev-feature-foo'),


### PR DESCRIPTION
Recently one of my projects failed with the following exception:

> Uncaught PHP Exception UnexpectedValueException: "Invalid version string "main"" at vendor/composer/semver/src/VersionParser.php line 186

Stating that "main" was considered an invalid version (I figure "dev-main" would be valid). 

As this comes from somewhere deep within the application or sub-dependencies, I figured it might be best to extend the version normalizer to handle both `main` and `dev-main`

This pull request aims to do exactly that. Applying the change to my local project fixed the exception.