### PR TITLE
Do not compact a dev-free constraint into a bare != that matches dev

### DIFF
--- a/src/Intervals.php
+++ b/src/Intervals.php
@@ -150,6 +150,17 @@ class Intervals
             $constraints[] = $intervals['numeric'][0]->getStart();
             $hasNumericMatchAll = true;
         } else {
+            // A bare "!= N" matches every dev-* version (see generateSingleConstraintIntervals),
+            // whereas "< N || > N" matches none. So the swap below must be skipped when it
+            // would collapse the whole numeric line (except N) into a bare != for a
+            // constraint that matches no dev version -- otherwise "> 1 != 2 || < 1.9"
+            // (no branch) becomes "!= 2" (every branch). A bounded conjunctive != such
+            // as [!= 3 < 5] keeps a numeric bound and stays dev-free, so it is fine.
+            // exclude === true means the dev baseline is "all dev" (any named branches
+            // are subtracted separately below), so a bare != is the right baseline;
+            // exclude === false means "no dev", where a bare != would wrongly add them.
+            $branchesMatchAllDev = $intervals['branches']['exclude'];
+
             $unEqualConstraints = array();
             for ($i = 0, $count = \count($intervals['numeric']); $i < $count; $i++) {
                 $interval = $intervals['numeric'][$i];
@@ -160,7 +171,10 @@ class Intervals
                 // they are zero/+inf
                 if ($interval->getEnd()->getOperator() === '<' && $i+1 < $count) {
                     $nextInterval = $intervals['numeric'][$i+1];
-                    if ($interval->getEnd()->getVersion() === $nextInterval->getStart()->getVersion() && $nextInterval->getStart()->getOperator() === '>') {
+                    $wouldBeBareNotEqual = 2 === $count
+                        && (string) $interval->getStart() === (string) Interval::fromZero()
+                        && (string) $nextInterval->getEnd() === (string) Interval::untilPositiveInfinity();
+                    if ($interval->getEnd()->getVersion() === $nextInterval->getStart()->getVersion() && $nextInterval->getStart()->getOperator() === '>' && ($branchesMatchAllDev || !$wouldBeBareNotEqual)) {
                         // only add a start if we didn't already do so, can be skipped if we're looking at second
                         // interval in [>=M, <N] || [>N, <P] || [>P, <Q] where unEqualConstraints currently contains
                         // [>=M, !=N] already and we only want to add !=P right now

--- a/tests/IntervalsTest.php
+++ b/tests/IntervalsTest.php
@@ -51,6 +51,25 @@ class IntervalsTest extends TestCase
         $this->assertSame((string) $expected, (string) $new);
     }
 
+    public function testCompactConstraintKeepsANumericOnlyConstraintDevFree()
+    {
+        $parser = new VersionParser;
+        // "> 1.0.0 != 2.0.0 || < 1.9.0" covers the whole numeric line except 2.0.0
+        // and matches no dev-* version. The numeric part compacts to a bare != 2.0.0,
+        // which on its own matches every dev branch, so compaction must not use it here.
+        $constraint = new MultiConstraint(array(
+            $parser->parseConstraints('> 1.0.0 != 2.0.0'),
+            $parser->parseConstraints('< 1.9.0'),
+        ), false);
+
+        $compacted = Intervals::compactConstraint($constraint);
+        $dev = new Constraint('==', $parser->normalize('dev-foo'));
+
+        $this->assertFalse($compacted->matches($dev), (string) $compacted);
+        $this->assertTrue(Intervals::isSubsetOf($compacted, $constraint));
+        $this->assertTrue(Intervals::isSubsetOf($constraint, $compacted));
+    }
+
     public static function compactProvider()
     {
         return array(


### PR DESCRIPTION
`compactConstraint()` rewrites `< N || > N` into `!= N`. Those are not equivalent
once dev versions are involved: a bare `!= N` matches every `dev-*` version, while
`< N || > N` matches none. So compacting a numeric-only constraint that covers the
whole line except N (and matches no dev branch) into a bare `!=` silently starts
matching every dev branch.

Skip the swap when it would produce that bare `!=` for a constraint whose branch
set isn't already "all dev". A bounded conjunctive `!=` such as `[!= 3 < 5]` keeps
a numeric bound and is unaffected.

Added a test that compacts `> 1.0.0 != 2.0.0 || < 1.9.0` and checks the result still
excludes `dev-foo` and stays an exact subset of the original both ways.
